### PR TITLE
fix: set `apt` extension `config_setting#visibility`

### DIFF
--- a/apt/private/deb_translate_lock.bzl
+++ b/apt/private/deb_translate_lock.bzl
@@ -81,6 +81,7 @@ _ARCHITECTURES = {architectures}
        "@platforms//os:" + os,
        "@platforms//cpu:" + _ARCHITECTURE_MAP[arch],
     ],
+    visibility = ["//:__subpackages__"],
   )
   for os in ["linux"]
   for arch in _ARCHITECTURES


### PR DESCRIPTION
Under `--incompatible_config_setting_private_default_visibility` the configuration setting is not available to downloaded packages `select` statements.

Expose it to `//:__subpackages__` so that the nested package `selects` are allowed to access it.