### PR TITLE
Fix link to GoogleContainerTools/distroless

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ check the following docs:
 
 # Adopters
 
-- [Google's `distroless` container images]
+- [Google's `distroless` container images](https://github.com/GoogleContainerTools/distroless)
 - [Arize AI](https://www.arize.com)
 
 > [!TIP]


### PR DESCRIPTION
Before it linked to bazel-contrib/distroless.  Now it links to GoogleContainerTools/distroless.