### PR TITLE
Add mergedusr support to apt.install()

### DIFF
--- a/apt/extensions.bzl
+++ b/apt/extensions.bzl
@@ -232,6 +232,34 @@ def _fetch_and_parse_sources(mctx, repo, glock, snapshot_suites, formats):
 
     return used_keys
 
+def compute_package_repo_modes(packages, roots_by_mode):
+    modes = {}
+
+    for (mergedusr, roots) in roots_by_mode.items():
+        pending = roots.keys()
+        seen = {}
+
+        for _ in range(len(packages)):
+            if not pending:
+                break
+
+            current = pending
+            pending = []
+            for package_key in current:
+                if package_key in seen:
+                    continue
+                if package_key not in packages:
+                    fail("illegal state: package %s is not in lockfile" % package_key)
+
+                seen[package_key] = True
+                modes.setdefault(package_key, {})[mergedusr] = True
+                pending.extend(packages[package_key]["depends_on"])
+
+        if pending:
+            fail("dependency traversal for package repository generation did not converge")
+
+    return modes
+
 def _distroless_extension(mctx):
     # Detect facts API availability
     use_facts = hasattr(mctx, "facts")
@@ -296,9 +324,18 @@ def _distroless_extension(mctx):
 
     resolution_queue = []
     already_resolved = {}
+    dependency_set_mergedusr = {}
+    package_repo_roots = {
+        False: {},
+        True: {},
+    }
 
     for mod in mctx.modules:
         for install in mod.tags.install:
+            if install.dependency_set:
+                current_mergedusr = dependency_set_mergedusr.get(install.dependency_set, False)
+                dependency_set_mergedusr[install.dependency_set] = current_mergedusr or install.mergedusr
+
             for dep_constraint in install.packages:
                 constraint = version_constraint.parse_dep(dep_constraint)
                 architectures = constraint["arch"]
@@ -327,6 +364,8 @@ def _distroless_extension(mctx):
                             constraint["version"],
                             "amd64",
                             install.suites,
+                            install.mergedusr,
+                            False,
                         ))
                         continue
 
@@ -340,6 +379,8 @@ def _distroless_extension(mctx):
                         constraint["version"],
                         arch,
                         install.suites,
+                        install.mergedusr,
+                        False,
                     ))
 
     for i in range(0, ITERATION_MAX + 1):
@@ -348,7 +389,7 @@ def _distroless_extension(mctx):
         if i == ITERATION_MAX:
             fail("apt.install exhausted, please file a bug")
 
-        (dependency_set_name, name, version, arch, suites) = resolution_queue.pop()
+        (dependency_set_name, name, version, arch, suites, mergedusr, is_transitive_dependency) = resolution_queue.pop()
 
         mctx.report_progress("Resolving %s:%s" % (name, arch))
 
@@ -400,6 +441,10 @@ def _distroless_extension(mctx):
         #  3- 1) is enforced even if 2) is the case.
         glock.add_package(package, arch)
 
+        package_key = lockfile.package_key(package, arch)
+        if not is_transitive_dependency:
+            package_repo_roots[mergedusr][package_key] = True
+
         pkg_short_key = lockfile.short_package_key(package, arch)
 
         already_resolved[pkg_short_key] = True
@@ -414,6 +459,8 @@ def _distroless_extension(mctx):
                     ("=", dep["Version"]),
                     arch,
                     suites,
+                    mergedusr,
+                    True,
                 ))
             glock.add_package_dependency(package, dep, arch)
 
@@ -427,11 +474,14 @@ def _distroless_extension(mctx):
 
     # Generate a hub repo for every dependency set
     lock_content = glock.as_json()
+    package_repo_modes = compute_package_repo_modes(glock.packages(), package_repo_roots)
     for depset_name in dependency_sets.keys():
+        depset_mergedusr = dependency_set_mergedusr.get(depset_name, False)
         translate_dependency_set(
             name = depset_name,
             depset_name = depset_name,
             lock_content = lock_content,
+            mergedusr = depset_mergedusr,
         )
 
     # Generate a repo per package which will be aliased by hub repo.
@@ -445,24 +495,30 @@ def _distroless_extension(mctx):
             files = json.encode(repo.filemap(name = name, arch = arch) or []),
         )
 
-        deb_import(
-            name = util.sanitize(package_key),
-            target_name = util.sanitize(package_key),
-            urls = [
-                uri + "/" + package["filename"]
-                for uri in sources[package["suite"]]["uris"]
-            ],
-            sha256 = package["sha256"],
-            mergedusr = False,
-            depends_on = package["depends_on"],
-            # Label of each dependency's own filemap, in depends_on order,
-            # so deb_import can rebuild the {file: dependency} index by lookup.
-            dep_filemaps = [
-                "@" + util.sanitize(dep) + "_filemap//:filemap.json"
-                for dep in package["depends_on"]
-            ],
-            package_name = package["name"],
-        )
+        modes = package_repo_modes.get(package_key, {False: True})
+        repo_variants = [(util.package_repo_name(package_key), False if False in modes else True)]
+        if True in modes:
+            repo_variants.append((util.package_repo_name(package_key, mergedusr = True), True))
+
+        for (repo_name, mergedusr) in repo_variants:
+            deb_import(
+                name = repo_name,
+                target_name = repo_name,
+                urls = [
+                    uri + "/" + package["filename"]
+                    for uri in sources[package["suite"]]["uris"]
+                ],
+                sha256 = package["sha256"],
+                mergedusr = mergedusr,
+                depends_on = package["depends_on"],
+                # Label of each dependency's own filemap, in depends_on order,
+                # so deb_import can rebuild the {file: dependency} index by lookup.
+                dep_filemaps = [
+                    "@" + util.sanitize(dep) + "_filemap//:filemap.json"
+                    for dep in package["depends_on"]
+                ],
+                package_name = package["name"],
+            )
 
     if not use_facts:
         for mod in mctx.modules:
@@ -527,7 +583,7 @@ apt.install(
 ```
 
 
-`apt.install` will install generate a package repository for each package and architecture
+`apt.install` generates a package repository for each package and architecture
 combination in the form of `@<TARGET_RELEASE>_<PKG_NAME>_<PKG_ARCH>`.
 
 Each `<PACKAGE>/<ARCH>` has two targets that match the usual structure of a
@@ -600,6 +656,7 @@ install = tag_class(
         "dependency_set": attr.string(),
         "suites": attr.string_list(),
         "include_transitive": attr.bool(default = True),
+        "mergedusr": attr.bool(default = False),
     },
 )
 

--- a/apt/private/BUILD.bazel
+++ b/apt/private/BUILD.bazel
@@ -89,6 +89,7 @@ bzl_library(
     srcs = ["translate_dependency_set.bzl"],
     visibility = ["//apt:__subpackages__"],
     deps = [
+        ":deb_postfix",
         ":lockfile",
         ":starlark_codegen_utils",
         ":util",
@@ -121,6 +122,7 @@ bzl_library(
     name = "deb_postfix",
     srcs = ["deb_postfix.bzl"],
     visibility = ["//apt:__subpackages__"],
+    deps = ["@tar.bzl//tar:tar"],
 )
 
 bzl_library(

--- a/apt/private/deb_import.bzl
+++ b/apt/private/deb_import.bzl
@@ -182,7 +182,7 @@ def _remap_linkopts(rctx, extract_dir, so_regular_files, self_files, depends_fil
 
     return result.linkopts
 
-def _discover_contents(rctx, depends_on, depends_file_map, target_name):
+def _discover_contents(rctx, depends_on, depends_file_map, target_name, mergedusr = False):
     result = rctx.execute(["tar", "--exclude='./usr/share/**'", "--exclude='./**/'", "-tvf", "data.tar.xz"])
     contents_raw = result.stdout.splitlines()
 
@@ -307,7 +307,7 @@ def _discover_contents(rctx, depends_on, depends_file_map, target_name):
     for dep in depends_on:
         (suite, name, arch, version) = lockfile.parse_package_key(dep)
         deps.append(
-            "@%s//:%s_wodeps" % (util.sanitize(dep), name.removesuffix("-dev")),
+            "@%s//:%s_wodeps" % (util.package_repo_name(dep, mergedusr = mergedusr), name.removesuffix("-dev")),
         )
 
     pkgconfigs = []
@@ -465,6 +465,7 @@ def _deb_import_impl(rctx):
         rctx.attr.depends_on,
         provided_by,
         rctx.attr.package_name.removesuffix("-dev"),
+        mergedusr = rctx.attr.mergedusr,
     )
 
     foreign_symlinks = {}
@@ -480,7 +481,7 @@ def _deb_import_impl(rctx):
 
     rctx.file("BUILD.bazel", _DEB_IMPORT_BUILD_TMPL.format(
         mergedusr = rctx.attr.mergedusr,
-        depends_on = ["@" + util.sanitize(dep_key) + "//:data" for dep_key in rctx.attr.depends_on],
+        depends_on = ["@" + util.package_repo_name(dep_key, mergedusr = rctx.attr.mergedusr) + "//:data" for dep_key in rctx.attr.depends_on],
         target_name = rctx.attr.target_name,
         cc_import_targets = cc_import_targets,
         outs = outs,

--- a/apt/private/translate_dependency_set.bzl
+++ b/apt/private/translate_dependency_set.bzl
@@ -140,9 +140,9 @@ alias(
 # this scoping, a package's `depends_on` (which spans every architecture the
 # lockfile knows about) would leak foreign-architecture deps into a single
 # architecture's target, causing file duplication that confuses `flatten`.
-def package_deps_for_architecture(packages, package, architecture):
+def package_deps_for_architecture(packages, package, architecture, mergedusr = False):
     return [
-        "@" + util.sanitize(dep_key) + "//:data"
+        "@" + util.package_repo_name(dep_key, mergedusr = mergedusr) + "//:data"
         for dep_key in package["depends_on"]
         if packages[dep_key]["architecture"] in [architecture, "all"]
     ]
@@ -173,7 +173,7 @@ def _translate_dependency_set_impl(rctx):
 
         for (short_key, version) in dependency_set["sets"][architecture].items():
             package_key = short_key + "=" + version
-            repo_name = util.sanitize(package_key)
+            repo_name = util.package_repo_name(package_key, mergedusr = rctx.attr.mergedusr)
             package = packages[package_key]
             package_name = package["name"]
 
@@ -207,7 +207,7 @@ Please unify the versions manually, or use separate `apt.install` calls (with di
                     data_targets = '"@%s//:data"' % repo_name,
                     control_targets = '"@%s//:control"' % repo_name,
                     src = '"@%s//:data"' % repo_name,
-                    deps = package_deps_for_architecture(packages, package, architecture),
+                    deps = package_deps_for_architecture(packages, package, architecture, mergedusr = rctx.attr.mergedusr),
                     urls = [
                         uri + "/" + package["filename"]
                         for uri in sources[package["suite"]]["uris"]
@@ -230,7 +230,7 @@ Please unify the versions manually, or use separate `apt.install` calls (with di
             extra = _DEB_CC_IMPORT.format(
                 target_name = target_name,
                 selects = starlark_codegen_utils.to_dict_attr({
-                    "//:linux_%s" % architecture: "@%s//:%s" % (util.sanitize(package_key), target_name)
+                    "//:linux_%s" % architecture: "@%s//:%s" % (util.package_repo_name(package_key, mergedusr = rctx.attr.mergedusr), target_name)
                     for (architecture, package_key) in info.architectures.items()
                 }),
             )
@@ -270,6 +270,7 @@ translate_dependency_set = repository_rule(
     attrs = {
         "depset_name": attr.string(doc = "INTERNAL: DO NOT USE"),
         "lock_content": attr.string(doc = "INTERNAL: DO NOT USE"),
+        "mergedusr": attr.bool(default = False, doc = "INTERNAL: Whether package layers were normalized with merged-/usr semantics."),
         "package_template": attr.label(default = "//apt/private:package.BUILD.tmpl"),
     },
 )

--- a/apt/private/util.bzl
+++ b/apt/private/util.bzl
@@ -25,6 +25,12 @@ def _get_dict(struct, keys = [], default_value = None):
 def _sanitize(str):
     return str.removeprefix("/").replace("+", "-").replace(":", "-").replace("~", "_").replace("/", "_").replace("=", "_")
 
+def _package_repo_name(package_key, mergedusr = False):
+    repo_name = _sanitize(package_key)
+    if mergedusr:
+        return repo_name + "_mergedusr"
+    return repo_name
+
 def _get_repo_name(st):
     if st.find("+") != -1:
         return st.split("+")[-1]
@@ -87,6 +93,7 @@ def _warning(rctx, message):
 
 util = struct(
     sanitize = _sanitize,
+    package_repo_name = _package_repo_name,
     set_dict = _set_dict,
     get_dict = _get_dict,
     warning = _warning,

--- a/apt/tests/BUILD.bazel
+++ b/apt/tests/BUILD.bazel
@@ -1,6 +1,7 @@
 load(":deb_postfix_test.bzl", "deb_postfix_tests")
 load(":dpkg_status_test.bzl", "dpkg_status_tests")
 load(":dpkg_statusd_test.bzl", "dpkg_statusd_tests")
+load(":extensions_test.bzl", "extensions_tests")
 load(":facts_test.bzl", "facts_tests")
 load(":linker_script_test.bzl", "linker_script_tests")
 load(":lockfile_test.bzl", "lockfile_tests")
@@ -25,3 +26,5 @@ linker_script_tests()
 lockfile_tests()
 
 translate_dependency_set_tests()
+
+extensions_tests()

--- a/apt/tests/extensions_test.bzl
+++ b/apt/tests/extensions_test.bzl
@@ -1,0 +1,53 @@
+"unit tests for apt.install mergedusr scoping"
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//apt:extensions.bzl", "compute_package_repo_modes")
+
+_TEST_SUITE_PREFIX = "extensions/"
+
+# Regression test for commit "Add mergedusr support to apt.install()".
+#
+# Before this fix, mergedusr was tracked as a single global boolean
+# (`mergedusr_enabled`) across *all* `apt.install` calls in a module, so a
+# single `apt.install(mergedusr = True)` call would force every other
+# `apt.install` call (even ones that never asked for mergedusr) to also be
+# built in mergedusr mode. `_package_repo_modes` instead computes, per
+# package, exactly which modes (mergedusr True/False) are actually needed
+# based on which root installs pulled it in transitively.
+def _scoped_mergedusr_test(ctx):
+    env = unittest.begin(ctx)
+
+    packages = {
+        "pkg-a": {"depends_on": []},
+        "pkg-b": {"depends_on": []},
+        "shared-dep": {"depends_on": []},
+    }
+
+    # Two independent apt.install roots: one with mergedusr=True (pkg-a),
+    # one without (pkg-b). Both depend on shared-dep.
+    roots_by_mode = {
+        False: {"pkg-b": True, "shared-dep": True},
+        True: {"pkg-a": True, "shared-dep": True},
+    }
+
+    modes = compute_package_repo_modes(packages, roots_by_mode)
+
+    # pkg-a only ever needed in mergedusr mode.
+    asserts.true(env, True in modes["pkg-a"])
+    asserts.false(env, False in modes["pkg-a"])
+
+    # pkg-b only ever needed without mergedusr.
+    asserts.true(env, False in modes["pkg-b"])
+    asserts.false(env, True in modes["pkg-b"])
+
+    # shared-dep is needed in BOTH modes, since it's pulled in by both roots.
+    # This is the crux of the fix: a single global flag could not represent this.
+    asserts.true(env, False in modes["shared-dep"])
+    asserts.true(env, True in modes["shared-dep"])
+
+    return unittest.end(env)
+
+scoped_mergedusr_test = unittest.make(_scoped_mergedusr_test)
+
+def extensions_tests():
+    scoped_mergedusr_test(name = _TEST_SUITE_PREFIX + "scoped_mergedusr")

--- a/apt/tests/translate_dependency_set_test.bzl
+++ b/apt/tests/translate_dependency_set_test.bzl
@@ -2,6 +2,7 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//apt/private:translate_dependency_set.bzl", "package_deps_for_architecture")
+load("//apt/private:util.bzl", "util")
 
 _TEST_SUITE_PREFIX = "translate_dependency_set/"
 
@@ -44,5 +45,22 @@ def _no_mixed_architectures_test(ctx):
 
 no_mixed_architectures_test = unittest.make(_no_mixed_architectures_test)
 
+# Regression test for commit "Add mergedusr support to apt.install()": package
+# repo names must be distinguishable per mergedusr mode so that the same
+# package can be materialized both with and without mergedusr normalization
+# when pulled in by different apt.install roots.
+def _package_repo_name_modes_test(ctx):
+    env = unittest.begin(ctx)
+
+    package_key = "/bullseye/bash:amd64=5.1"
+
+    asserts.equals(env, "bullseye_bash-amd64_5.1", util.package_repo_name(package_key))
+    asserts.equals(env, "bullseye_bash-amd64_5.1_mergedusr", util.package_repo_name(package_key, mergedusr = True))
+
+    return unittest.end(env)
+
+package_repo_name_modes_test = unittest.make(_package_repo_name_modes_test)
+
 def translate_dependency_set_tests():
     no_mixed_architectures_test(name = _TEST_SUITE_PREFIX + "no_mixed_architectures")
+    package_repo_name_modes_test(name = _TEST_SUITE_PREFIX + "package_repo_name_modes")

--- a/examples/flatten/BUILD.bazel
+++ b/examples/flatten/BUILD.bazel
@@ -110,10 +110,10 @@ assert_tar_listing(
     name = "test_flatten_dedup_listing",
     actual = "flatten_dedup",
     expected = """\
-flatten/
-flatten/dir/
-flatten/dir/changelog
-flatten/dir/sub/
-flatten/dir/sub/content.txt
+./flatten/
+./flatten/dir/
+./flatten/dir/changelog
+./flatten/dir/sub/
+./flatten/dir/sub/content.txt
 """,
 )


### PR DESCRIPTION
Introduces per-package/per-dependency-set mergedusr normalization for apt.install():

- apt.install() gains a `mergedusr` attribute. When set, the hub repo (translate_dependency_set) generates a mergedusr_compat symlink tar (bin/sbin/lib*/usr/... symlinks) using Bazel's native tar() rule with mtree directives, folded into the dependency set's :flat output.
- Packages are materialized per required mode (util.package_repo_name) so the same package can be built once with, and once without, mergedusr normalization, depending on which apt.install root(s) pull it in. compute_package_repo_modes() computes this scoping transitively so one apt.install(mergedusr=True) call cannot leak mergedusr behavior into unrelated apt.install calls that share dependencies.
- deb_import()'s existing mergedusr attribute is reused unchanged; only the naming/scoping around it is new.